### PR TITLE
Add TweetClaw X/Twitter plugin to Skills & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ openclaw skill remove steipete/slack
 | `perplexity-search` | Deep web search via Perplexity API |
 | `supermemory` | External memory layer backed by Supermemory.ai |
 
+**Social Media:**
+
+| Skill | What it does | When to use it |
+|---|---|---|
+| [`tweetclaw`](https://github.com/Xquik-dev/tweetclaw) | Full X/Twitter automation — 120 endpoints for tweets, replies, likes, follows, DMs, extractions, and giveaway draws | When you need X/Twitter read/write from your agent; reads from $0.00015/call via Xquik API |
+
 ### Skills by Category
 For the full categorized index of 5,400+ vetted skills:
 ➡️ [**VoltAgent/awesome-openclaw-skills**](https://github.com/VoltAgent/awesome-openclaw-skills) — 1M+ monthly views, the #1 community skills resource.


### PR DESCRIPTION
## What

Adding [TweetClaw](https://github.com/Xquik-dev/tweetclaw) to the **Skills & Plugins** section under a new **Social Media** sub-table.

## Why it belongs

- **What:** Full X/Twitter automation plugin for OpenClaw - 120 endpoints covering tweets, replies, likes, follows, DMs, bulk extractions, monitoring, and giveaway draws.
- **Who:** Anyone who needs X/Twitter read/write capabilities from their OpenClaw agent.
- **Why it matters:** Cheapest X API access available (reads from $0.00015/call, 33x cheaper than official X API). Published on [ClawHub](https://clawhub.ai/plugins/%40xquik%2Ftweetclaw) and npm (`@xquik/tweetclaw`). MIT licensed, actively maintained.

No existing Social Media sub-category existed - added one since X/Twitter automation is a common agent use case.

Disclosure: I'm a maintainer of TweetClaw / Xquik.
