### PR TITLE
Add lucinate-ai/lucinate to UIs & Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Browse 13,000+ MCP servers at [mcp.so](https://mcp.so) or the [official MCP serv
 
 | Tool | Platform | Description |
 |---|---|---|
+| [lucinate-ai/lucinate](https://github.com/lucinate-ai/lucinate) | Cross-platform (Linux, macOS, Windows) | Terminal-native TUI chat client for OpenClaw, Hermes, and OpenAI-compatible endpoints |
 | [OpenClaw for macOS](https://docs.openclaw.ai/platforms/macos) | macOS | Menu bar companion app; manages/connects to local Gateway and exposes macOS capabilities as nodes to the agent |
 | [OpenClaw Manager](https://github.com/miaoxworld/openclaw-manager) | macOS / Windows | Desktop chat interface with visual file management |
 | [OpenClaw Windows Hub](https://github.com/openclaw/openclaw-windows-node) | Windows | Windows companion suite for OpenClaw (AI personal assistant) |

--- a/README.md
+++ b/README.md
@@ -498,6 +498,12 @@ Browse 13,000+ MCP servers at [mcp.so](https://mcp.so) or the [official MCP serv
 | [OpenClaw iOS App](https://docs.openclaw.ai/platforms/ios) | iOS | **Internal preview — not yet publicly released.** Connects to Gateway via WebSocket (LAN or tailnet); exposes node capabilities: canvas, screenshot, camera capture, location, call mode, voice wake. Receives `node.invoke` commands and reports node status events |
 | [OpenClaw Android Node](https://docs.openclaw.ai/platforms/android) | Android | Official Android platform docs; community APK build at [openclaw-android-node-apk](https://github.com/bighamx/openclaw-android-node-apk) |
 
+### Terminal (TUI)
+
+| Tool | Description | Key Feature |
+|---|---|---|
+| [lucinate](https://github.com/lucinate-ai/lucinate) | Multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs | Reusable prompt routines, tool call cards, multi-agent switching, local agent skills |
+
 ---
 
 ## 🌐 Platform Channels & Messaging


### PR DESCRIPTION
Add [lucinate](https://github.com/lucinate-ai/lucinate) - a terminal-native TUI chat client written in Go that connects to OpenClaw gateways over WebSocket (Ed25519 paired), as well as any OpenAI-compatible endpoint and Hermes agent profiles.

**Section:** 🖥️ UIs & Companion Apps (Desktop Apps)
**Public signal:** Active GitHub development, Homebrew tap, cross-platform install scripts, public website at lucinate.ai