### PR TITLE
docs: add RapidClaw to managed hosting table

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ Browse 13,000+ MCP servers at [mcp.so](https://mcp.so) or the [official MCP serv
 | [Tinkerclaw](https://tinkerclaw.com) | ~$49/month | Full onboarding support + OpenClaw Manager |
 | [OpenClaw Launch](https://openclawlaunch.com) | ~$20/month | Simple managed + pre-configured skills |
 | [DigitalOcean 1-Click](https://marketplace.digitalocean.com/apps/openclaw) | $12/month | Self-hosted but fast; full root access |
+| [RapidClaw](https://rapidclaw.dev) | $29/month | Non-technical operators — no Docker, SSH, or API key juggling |
 
 ### Self-Hosted: Docker Compose
 


### PR DESCRIPTION
Adds RapidClaw to the Deployment & Infrastructure → Managed Hosting table, alongside the existing ClawHost / Tinkerclaw / OpenClaw Launch / DigitalOcean entries.

**Affiliation disclosure:** I am the founder of RapidClaw. Submitted following the format of existing rows in the section. Public site: https://rapidclaw.dev — pricing page lists 3 tiers from \$29/mo.