### PR TITLE
Add NotFair under Notable MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ openclaw mcp add --local /path/to/my-mcp-server --name local-tools
 | [postgres-mcp](https://github.com/crystaldba/postgres-mcp) | Database | Read-only PostgreSQL access |
 | [slack-mcp](https://mcp.slack.com) | Comms | Official Slack MCP |
 | [gmail-mcp](https://gmail.mcp.claude.com) | Email | Gmail via MCP |
+| [notfair](https://notfair.co) | Marketing | Hosted Google Ads MCP — diagnose, recommend, and execute campaign changes via the Google Ads API |
 
 Browse 13,000+ MCP servers at [mcp.so](https://mcp.so) or the [official MCP server directory](https://github.com/modelcontextprotocol/servers).
 


### PR DESCRIPTION
Adding NotFair under Notable MCP Servers. It's a hosted Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

There's no Marketing entry in the table yet, so I added it as the first one. Linked to the product page since it's a hosted SaaS rather than an open repo, similar to slack-mcp and gmail-mcp already listed.

Happy to adjust the format or category name if you'd prefer.