### PR TITLE
Add APort agent guardrails to security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ openclaw secureclaw harden
 | Tool | Description |
 |---|---|
 | [skill-guard](https://clawhub.ai/jamesOuttake/skill-guard) | Scan ClawHub skills for security vulnerabilities before installing — detects prompt injection, malware payloads, hardcoded keys and other threats |
+| [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) | Pre-action authorization guardrails that check AI agent tool calls and sensitive actions against policy before execution |
 | [agent-audit-trail skill](https://clawhub.ai/community/agent-audit-trail) | Tamper-evident hash-chained action logging |
 | [agent-access-control skill](https://clawhub.ai/community/agent-access-control) | Tiered access control per user/channel |
 


### PR DESCRIPTION
## Summary

Adds APort Agent Guardrails to the OpenClaw security tools table.

## Why

OpenClaw users need explicit control around agent actions and tool calls. APort Agent Guardrails is a focused fit for the existing security section because it performs pre-action authorization checks before sensitive agent operations run.

## Verification

- `git diff --check`

Related awareness bounty: aporthq/aport-integrations#19