### PR TITLE
Add TWZRD Agent Intel to Notable MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ openclaw mcp add --local /path/to/my-mcp-server --name local-tools
 | [postgres-mcp](https://github.com/crystaldba/postgres-mcp) | Database | Read-only PostgreSQL access |
 | [slack-mcp](https://mcp.slack.com) | Comms | Official Slack MCP |
 | [gmail-mcp](https://gmail.mcp.claude.com) | Email | Gmail via MCP |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Web3 / Trust | Solana agent trust scoring + x402/USDC receipt verification; zero-install HTTP MCP |
 
 Browse 13,000+ MCP servers at [mcp.so](https://mcp.so) or the [official MCP server directory](https://github.com/modelcontextprotocol/servers).
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Notable MCP Servers table in the MCP Integrations section.

**Category**: Web3 / Trust scoring

**What it does**: Solana agent trust scoring and on-chain receipt verification — useful for OpenClaw agents that transact with other agents on Solana and need to verify counterpart trust. Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Paid tool: `get_trust_receipt` (via x402/USDC micropayment).

**Zero-install** (Streamable HTTP transport):
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

More info: [intel.twzrd.xyz](https://intel.twzrd.xyz)