### PR TITLE
Add RouterBase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ n8n is a visual workflow automation tool for non-technical users. OpenClaw is a 
 |---|---|
 | [ClawRouter](https://github.com/BlockRunAI/ClawRouter) | Agent-native LLM router supporting 41+ models, sub-1ms routing latency, USDC payments via x402 on Base and Solana |
 | [Model Router](https://clawhub.ai/MrJootta/model-router-premium) | Routes model requests based on configured models, costs and task complexity — general/low-complexity requests to the cheapest available model, higher-complexity to stronger models |
+| [RouterBase Agent Skills](https://github.com/zenlee123/routerbase-agent-skills) | Agent skills for using [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway: migrate API calls, plan model routing/fallbacks, and run media generation workflows |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -868,6 +868,7 @@ n8n 是面向非技术用户的可视化工作流自动化工具；OpenClaw 是�
 |---|---|
 | [ClawRouter](https://github.com/BlockRunAI/ClawRouter) | Agent 原生 LLM 路由器，支持 41+ 模型，路由延迟低于 1 毫秒，支持通过 x402 在 Base 和 Solana 上进行 USDC 支付 |
 | [Model Router](https://clawhub.ai/MrJootta/model-router-premium) | 根据配置的模型、成本和任务复杂度自动路由请求——简单/低复杂度任务路由到最便宜的模型，高复杂度任务路由到更强的模型 |
+| [RouterBase Agent Skills](https://github.com/zenlee123/routerbase-agent-skills) | 面向 [routerbase](https://routerbase.com/) 的 Agent Skills：迁移 OpenAI-compatible API 调用、规划模型路由/故障回退，并接入图片、视频、音频生成工作流 |
 
 ---
 


### PR DESCRIPTION
## Summary

Add RouterBase Agent Skills to the Cost Optimization section in both English and Chinese README files. The entry is positioned next to existing LLM routing/model-router resources.

Included website anchor: [routerbase](https://routerbase.com/).

## Why it fits

RouterBase Agent Skills provide SKILL.md guidance for OpenAI-compatible API migration, model routing/fallback planning, and media generation workflows. The resource is public and uses placeholders rather than real credentials.

## Checks

- Ran `git diff --check`
- Scanned README.md, README_CN.md, and CONTRIBUTING.md for common secrets/tokens/password patterns; no matches found